### PR TITLE
Compile fixes for kernel 5.15.2

### DIFF
--- a/binder/binder.c
+++ b/binder/binder.c
@@ -2435,7 +2435,11 @@ static int binder_translate_binder(struct flat_binder_object *fp,
 		ret = -EINVAL;
 		goto done;
 	}
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,2))
+	if (security_binder_transfer_binder(proc->tsk->real_cred, target_proc->tsk->real_cred)) {
+#else
 	if (security_binder_transfer_binder(proc->tsk, target_proc->tsk)) {
+#endif
 		ret = -EPERM;
 		goto done;
 	}
@@ -2481,7 +2485,11 @@ static int binder_translate_handle(struct flat_binder_object *fp,
 				  proc->pid, thread->pid, fp->handle);
 		return -EINVAL;
 	}
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,2))
+	if (security_binder_transfer_binder(proc->tsk->real_cred, target_proc->tsk->real_cred)) {
+#else
 	if (security_binder_transfer_binder(proc->tsk, target_proc->tsk)) {
+#endif
 		ret = -EPERM;
 		goto done;
 	}
@@ -2569,7 +2577,11 @@ static int binder_translate_fd(u32 fd, binder_size_t fd_offset,
 		ret = -EBADF;
 		goto err_fget;
 	}
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,2))
+	ret = security_binder_transfer_file(proc->tsk->real_cred, target_proc->tsk->real_cred, file);
+#else
 	ret = security_binder_transfer_file(proc->tsk, target_proc->tsk, file);
+#endif
 	if (ret < 0) {
 		ret = -EPERM;
 		goto err_security;
@@ -2967,8 +2979,13 @@ static void binder_transaction(struct binder_proc *proc,
 			return_error_line = __LINE__;
 			goto err_invalid_target_handle;
 		}
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,2))
+		if (security_binder_transaction(proc->tsk->real_cred,
+						target_proc->tsk->real_cred) < 0) {
+#else
 		if (security_binder_transaction(proc->tsk,
 						target_proc->tsk) < 0) {
+#endif
 			return_error = BR_FAILED_REPLY;
 			return_error_param = -EPERM;
 			return_error_line = __LINE__;
@@ -4910,7 +4927,11 @@ static int binder_ioctl_set_ctx_mgr(struct file *filp,
 		ret = -EBUSY;
 		goto out;
 	}
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,2))
+	ret = security_binder_set_context_mgr(proc->tsk->real_cred);
+#else
 	ret = security_binder_set_context_mgr(proc->tsk);
+#endif
 	if (ret < 0)
 		goto out;
 	if (uid_valid(context->binder_context_mgr_uid)) {


### PR DESCRIPTION
Linux 5.15.2 updated security.h  security_binder_* functions (like security_binder_transfer_binder(), so it uses struct cred* instead of struct task_struct*)