### PR TITLE
Patches for kernel 5.19

### DIFF
--- a/binder/binder.c
+++ b/binder/binder.c
@@ -2236,7 +2236,9 @@ static void binder_deferred_fd_close(int fd)
 	if (!twcb)
 		return;
 	init_task_work(&twcb->twork, binder_do_fd_close);
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0))
+    twcb->file = close_fd_get_file(fd);
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
 	close_fd_get_file(fd, &twcb->file);
 #else
 	__close_fd_get_file(fd, &twcb->file);

--- a/binder/binder.c
+++ b/binder/binder.c
@@ -2244,6 +2244,9 @@ static void binder_deferred_fd_close(int fd)
 	__close_fd_get_file(fd, &twcb->file);
 #endif
 	if (twcb->file) {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0))
+        get_file(twcb->file);
+#endif
 		filp_close(twcb->file, current->files);
 		task_work_add(current, &twcb->twork, TWA_RESUME);
 	} else {

--- a/binder/deps.c
+++ b/binder/deps.c
@@ -70,11 +70,12 @@ static unsigned long kallsyms_lookup_name_wrapper(const char *name)
 #endif
 }
 
-static int (*close_fd_get_file_ptr)(unsigned int fd
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,19,0))
-        , struct file **res
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0))
+static struct file *(*close_fd_get_file_ptr)(unsigned int fd)
+#else
+static int (*close_fd_get_file_ptr)(unsigned int fd, struct file **res)
 #endif
-        ) = NULL;
+        = NULL;
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0))
 struct file *close_fd_get_file(unsigned int fd)


### PR DESCRIPTION
This update reflects the signature change in `close_fd_get_file_ptr` from `int close_fd_get_file_ptr(unsigned int fd, struct file **res)` to `struct file *close_fd_get_file_ptr(unsigned int fd)`.