### PR TITLE
Fix build on 6.0 kernel

### DIFF
--- a/ashmem/ashmem.c
+++ b/ashmem/ashmem.c
@@ -874,7 +874,11 @@ static int __init ashmem_init(void)
 		return ret;
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0))
+	register_shrinker(&ashmem_shrinker, "android-ashmem");
+#else
 	register_shrinker(&ashmem_shrinker);
+#endif
 
 	return 0;
 }

--- a/binder/binder_alloc.c
+++ b/binder/binder_alloc.c
@@ -23,6 +23,7 @@
 #include <linux/uaccess.h>
 #include <linux/highmem.h>
 #include <linux/sizes.h>
+#include <linux/version.h>
 #include "binder_alloc.h"
 #include "binder_trace.h"
 
@@ -1079,7 +1080,11 @@ int binder_alloc_shrinker_init(void)
 	int ret = list_lru_init(&binder_alloc_lru);
 
 	if (ret == 0) {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0))
+		ret = register_shrinker(&binder_shrinker, "android-binder");
+#else
 		ret = register_shrinker(&binder_shrinker);
+#endif
 		if (ret)
 			list_lru_destroy(&binder_alloc_lru);
 	}


### PR DESCRIPTION
This fixes build failure on 6.0 Kernel because `register_shrinker` needs a new parameter.

`android-binder` is an official value (https://github.com/torvalds/linux/blob/master/drivers/android/binder_alloc.c#L1082).
`android-ashmem` is not official because ashmem has been dropped since Kernel 5.17-rc8 (https://github.com/torvalds/linux/commit/721412ed3d819e767cac2b06646bf03aa158aaec), I just follow binder's pattern to name it `android-ashmem`.

Now ashmem has been replaced with memfd, we also suggest drop ashmem here. I tested binder on waydroid and it works fine, while ashmem is not tested because waydroid can use memfd as its replacement now.