### PR TITLE
Fix build on 6.1 kernel

### DIFF
--- a/binder/binder.c
+++ b/binder/binder.c
@@ -4109,7 +4109,9 @@ static int binder_wait_for_work(struct binder_thread *thread,
 	struct binder_proc *proc = thread->proc;
 	int ret = 0;
 
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(6,0,0)
 	freezer_do_not_count();
+#endif
 	binder_inner_proc_lock(proc);
 	for (;;) {
 		prepare_to_wait(&thread->wait, &wait, TASK_INTERRUPTIBLE);
@@ -4129,7 +4131,9 @@ static int binder_wait_for_work(struct binder_thread *thread,
 	}
 	finish_wait(&thread->wait, &wait);
 	binder_inner_proc_unlock(proc);
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(6,0,0)
 	freezer_count();
+#endif
 
 	return ret;
 }

--- a/binder/binder.c
+++ b/binder/binder.c
@@ -4114,7 +4114,7 @@ static int binder_wait_for_work(struct binder_thread *thread,
 #endif
 	binder_inner_proc_lock(proc);
 	for (;;) {
-		prepare_to_wait(&thread->wait, &wait, TASK_INTERRUPTIBLE);
+		prepare_to_wait(&thread->wait, &wait, TASK_INTERRUPTIBLE|TASK_FREEZABLE);
 		if (binder_has_work_ilocked(thread, do_proc_work))
 			break;
 		if (do_proc_work)


### PR DESCRIPTION
It seems that they simplified some code on version 6.1 and we should also adjust this module.
See https://github.com/torvalds/linux/commit/f5d39b020809146cc28e6e73369bf8065e0310aa for more info.