### PR TITLE
fixed build on 6.5.9 on Opensuse Tumbleweed

### DIFF
--- a/ashmem/ashmem.c
+++ b/ashmem/ashmem.c
@@ -390,7 +390,8 @@ static int ashmem_mmap(struct file *file, struct vm_area_struct *vma)
 		ret = -EPERM;
 		goto out;
 	}
-	vma->vm_flags &= ~calc_vm_may_flags(~asma->prot_mask);
+	vma->vm_flags;
+	 ~calc_vm_may_flags(~asma->prot_mask);
 
 	if (!asma->file) {
 		char *name = ASHMEM_NAME_DEF;


### PR DESCRIPTION
I had this issue where GCC gave this error when compiling the ashmem module: 

/var/lib/dkms/anbox-ashmem/1/build/ashmem.c:393:23: error: assignment of read-only member ‘vm_flags’

This has worked so far on my system and Waydroid starts and ashmem loads correctly.