### PR TITLE
Fix build for 6.6

### DIFF
--- a/ashmem/ashmem.c
+++ b/ashmem/ashmem.c
@@ -390,7 +390,7 @@ static int ashmem_mmap(struct file *file, struct vm_area_struct *vma)
 		ret = -EPERM;
 		goto out;
 	}
-	vma->vm_flags &= ~calc_vm_may_flags(~asma->prot_mask);
+	vm_flags_clear(vma, calc_vm_may_flags(~asma->prot_mask));
 
 	if (!asma->file) {
 		char *name = ASHMEM_NAME_DEF;

--- a/ashmem/ashmem.c
+++ b/ashmem/ashmem.c
@@ -390,7 +390,11 @@ static int ashmem_mmap(struct file *file, struct vm_area_struct *vma)
 		ret = -EPERM;
 		goto out;
 	}
-	vm_flags_clear(vma, calc_vm_may_flags(~asma->prot_mask));
+	#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+		vm_flags_clear(vma, calc_vm_may_flags(~asma->prot_mask));
+	#else
+		vma->vm_flags &= ~calc_vm_may_flags(~asma->prot_mask);
+	#endif
 
 	if (!asma->file) {
 		char *name = ASHMEM_NAME_DEF;


### PR DESCRIPTION
Fixed build implementing the solution as discussed in the LKML for kernels 6.3+ regarding the manipulation of vm_flags:

Source: https://lore.kernel.org/lkml/CAJuCfpETYdLRigLTHe6HHQrC5vy5MmDc=HPsuMc6UKEzfr22ZA@mail.gmail.com/