### PR TITLE
Fixes for kernel 6.8

### DIFF
--- a/binder/binder.c
+++ b/binder/binder.c
@@ -2236,7 +2236,9 @@ static void binder_deferred_fd_close(int fd)
 	if (!twcb)
 		return;
 	init_task_work(&twcb->twork, binder_do_fd_close);
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0))
+    twcb->file = file_close_fd(fd);
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0))
     twcb->file = close_fd_get_file(fd);
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
 	close_fd_get_file(fd, &twcb->file);

--- a/binder/deps.c
+++ b/binder/deps.c
@@ -77,7 +77,9 @@ static int (*close_fd_get_file_ptr)(unsigned int fd, struct file **res)
 #endif
         = NULL;
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0))
+struct file *file_close_fd(unsigned int fd)
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0))
 struct file *close_fd_get_file(unsigned int fd)
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
 int close_fd_get_file(unsigned int fd, struct file **res)
@@ -86,7 +88,9 @@ int __close_fd_get_file(unsigned int fd, struct file **res)
 #endif
 {
 	if (!close_fd_get_file_ptr)
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0))
+		close_fd_get_file_ptr = kallsyms_lookup_name_wrapper("file_close_fd");
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
 		close_fd_get_file_ptr = kallsyms_lookup_name_wrapper("close_fd_get_file");
 #else
 		close_fd_get_file_ptr = kallsyms_lookup_name_wrapper("__close_fd_get_file");


### PR DESCRIPTION
## Modifications
* Break changes on `list_lru_add` and `list_lru_del`, in favor of `list_lru_add_obj` and `list_lru_del_obj`
* Break changes on `close_fd_get_file`, in favor of `file_close_fd`

Tested on linux 6.8 rc-2 and linux 6.7.2