### PR TITLE
removed obsolete NAME="%k", added binder symlink

### DIFF
--- a/99-anbox.rules
+++ b/99-anbox.rules
@@ -1,2 +1,2 @@
-KERNEL=="ashmem", NAME="%k", MODE="0666"
-KERNEL=="binder*", NAME="%k", MODE="0666"
+KERNEL=="ashmem", MODE="0666"
+KERNEL=="binder*", MODE="0666", SYMLINK+="anbox-%k"

--- a/99-anbox.rules
+++ b/99-anbox.rules
@@ -1,2 +1,2 @@
-KERNEL=="ashmem", NAME="%k", MODE="0666"
-KERNEL=="binder*", NAME="%k", MODE="0666"
+KERNEL=="ashmem", MODE="0666"
+KERNEL=="binder*", MODE="0666" SYMLINK+="anbox-%k"


### PR DESCRIPTION
removed obsolete NAME="%k", added binder symlink
ref: NAME
         The name to use for a network interface. See
         systemd.link(5) for a higher-level mechanism
         for setting the interface name. The name of a
         device node cannot be changed by udev, only
         additional symlinks can be created.
