### PR TITLE
fix creation of all 3 anbox binder module symlinks

### DIFF
--- a/99-anbox.rules
+++ b/99-anbox.rules
@@ -1,2 +1,2 @@
 KERNEL=="ashmem", MODE="0666"
-KERNEL=="binder*", MODE="0666", SYMLINK+="anbox-%k"
+KERNEL=="*binder", MODE="0666", SYMLINK+="anbox-%k"


### PR DESCRIPTION
This creates 3 symlinks for the  3 modules, otherwise just `binder` is symlinked.
`waydroid` components crash with the following error: 
```
Binder driver could not be opened. Terminating.
```

I _guess_ (it worked after creating all 3 symlinks) this is happening because 2 devices are not available, not being symlinked.

Here's what `waydroid` is expecting:

```
# grep anbox /var/lib/waydroid/lxc/waydroid/config_nodes
lxc.mount.entry = /dev/anbox-binder dev/binder none bind,create=file,optional 0 0
lxc.mount.entry = /dev/anbox-vndbinder dev/vndbinder none bind,create=file,optional 0 0
lxc.mount.entry = /dev/anbox-hwbinder dev/hwbinder none bind,create=file,optional 0 0
```

This is how `/dev` looks like after this change:

```
lrwxrwxrwx  1 root root               6 May 26 11:56 anbox-binder -> binder
lrwxrwxrwx  1 root root               8 May 26 11:56 anbox-hwbinder -> hwbinder
lrwxrwxrwx  1 root root               9 May 26 11:56 anbox-vndbinder -> vndbinder
crw-rw-rw-  1 root root       10,   122 May 26 11:56 binder
crw-rw-rw-  1 root root       10,   121 May 26 11:56 hwbinder
crw-rw-rw-  1 root root       10,   120 May 26 11:56 vndbinder
```