### PR TITLE
Fix for Linux 6.19

### DIFF
--- a/binder/binderfs.c
+++ b/binder/binderfs.c
@@ -819,7 +819,7 @@ static struct file_system_type binder_fs_type = {
 	.name			= "binder",
 	.init_fs_context	= binderfs_init_fs_context,
 	.parameters		= binderfs_fs_parameters,
-	.kill_sb		= kill_litter_super,
+	.kill_sb		= kill_anon_super,
 	.fs_flags		= FS_USERNS_MOUNT,
 };
 


### PR DESCRIPTION
As kill_litter_super has been removed due to d_genocide being removed in 6.19, the kernel developer has explicitly stated to use kill_anon_super instead.