### PR TITLE
fix for RHEL 10.1

### DIFF
--- a/binder/binder_alloc.c
+++ b/binder/binder_alloc.c
@@ -26,6 +26,7 @@
 #include <linux/version.h>
 #include "binder_alloc.h"
 #include "binder_trace.h"
+#include "compat_version.h"
 
 struct list_lru binder_alloc_lru;
 
@@ -1073,7 +1074,8 @@ static unsigned long
 binder_shrink_scan(struct shrinker *shrink, struct shrink_control *sc)
 {
 	unsigned long ret;
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0) || \
+     defined(RHEL_10_1_BACKPORTS))
 	ret = list_lru_walk(&binder_alloc_lru, binder_alloc_free_page_no_lock,
 				NULL, sc->nr_to_scan);
 #else

--- a/binder/compat_version.h
+++ b/binder/compat_version.h
@@ -1,0 +1,10 @@
+#ifndef __COMPAT_VERSION_H__
+#   define __COMPAT_VERSION_H__
+
+#if defined(RHEL_RELEASE_CODE) && defined(RHEL_RELEASE_VERSION)
+#   if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(10, 1)
+#      define RHEL_10_1_BACKPORTS 1
+#   endif
+#endif
+
+#endif /* __COMPAT_VERSION_H__ */


### PR DESCRIPTION
RHEL regularly changes the Kernel ABI without updating LINUX_VERSION_CODE.

Around `6.12.0-76.el10` (and forward) various changes have been introduced in `list_lru*`, requiring (for now) one backport from the `6.13` kernel patches (commit 355b6d8bdd70c29ed01ee7b2c782a43adccee1d1) for RHEL 10.1+.

Full RHEL kernel changelog: https://git.rockylinux.org/staging/rpms/kernel/-/blob/r10/SOURCES/kernel.changelog

