### PR TITLE
Add old static symlinks needed by gbinder

### DIFF
--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -14,3 +14,11 @@ sudo dkms install anbox-binder/1
 sudo modprobe binder_linux
 lsmod | grep -e binder_linux
 ls -alh /dev/binder
+
+#Add symlinks to devices needed by gbinder
+sudo ln -s /dev/binderfs/anbox-binder /dev/binder
+sudo ln -s /dev/binderfs/anbox-hwbinder /dev/hwbinder
+sudo ln -s /dev/binderfs/anbox-vndbinder /dev/vndbinder
+sudo chmod 777 /dev/binder
+sudo chmod 777 /dev/hwbinder
+sudo chmod 777 /dev/vndbinder

--- a/UNINSTALL.sh
+++ b/UNINSTALL.sh
@@ -10,6 +10,11 @@ sudo rm -rf /usr/src/anbox-binder-1
 sudo rm -f /etc/modules-load.d/anbox.conf
 sudo rm -f /lib/udev/rules.d/99-anbox.rules
 
+#Remove symlinks
+sudo rm /dev/binder
+sudo rm /dev/hwbinder
+sudo rm /dev/vndbinder
+
 # Verify remove by trying to load the modules and checking the created devices:
 failed_checks=0
 if sudo modprobe binder_linux > /dev/null 2>&1; then


### PR DESCRIPTION
Waydroid still needs the traditional, static _/dev/binder_ device to work.
I've added a symlink _/dev/binder_ that points to _/dev/binderfs/anbox-binder_.