### PR TITLE
binder: fix missing prototype for zap_page_range_single

### DIFF
--- a/binder/binder_alloc.c
+++ b/binder/binder_alloc.c
@@ -27,6 +27,7 @@
 #include "binder_alloc.h"
 #include "binder_trace.h"
 #include "compat_version.h"
+#include "deps.h"
 
 struct list_lru binder_alloc_lru;
 

--- a/binder/deps.h
+++ b/binder/deps.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
 #include <linux/ipc_namespace.h>
-#include <linux/mm.h>
 
 struct ipc_namespace* get_init_ipc_ns_ptr(void);
 void zap_page_range_single(struct vm_area_struct *vma, unsigned long address,

--- a/binder/deps.h
+++ b/binder/deps.h
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0
 
 #include <linux/ipc_namespace.h>
+#include <linux/mm.h>
 
 struct ipc_namespace* get_init_ipc_ns_ptr(void);
+void zap_page_range_single(struct vm_area_struct *vma, unsigned long address,
+			    unsigned long size, struct zap_details *details);


### PR DESCRIPTION
## Problem

Building `binder` fails on recent kernels (e.g. 7.1.1) with newer Clang toolchains:

```
binder_alloc.c:1029:3: error: call to undeclared function 'zap_page_range_single';
ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
```

## Root cause

`deps.c` implements `zap_page_range_single()` as a runtime compat shim (resolved via `kallsyms_lookup_name`) for kernels where it isn't available as a normal export. However:

- `deps.h` never declares a prototype for it (only `get_init_ipc_ns_ptr()` is declared).
- `binder_alloc.c`, which calls `zap_page_range_single()`, does not `#include "deps.h"`.

So when `binder_alloc.c` is compiled, the compiler has no declaration of `zap_page_range_single` in scope. Older compilers treated this as a warning; newer Clang (and GCC in C99+ mode) treats implicit function declarations as a hard error, breaking the build.

## Fix

- Declare the prototype for `zap_page_range_single()` in `deps.h`.
- `#include "deps.h"` from `binder_alloc.c`.

## Testing

Built `binder/` standalone against kernel 7.1.1-2 headers with `clang` + `ld.lld`:

- Before the fix: fails at `binder_alloc.o` with the implicit-declaration error above.
- After the fix: `binder_alloc.o` compiles cleanly and `binder_linux.ko` links and builds successfully end to end.